### PR TITLE
Upgrade download/upload artifacts and cache actions version to v4

### DIFF
--- a/.github/workflows/main_itazchat2-webapp-rxjah4bntxkd2.yml
+++ b/.github/workflows/main_itazchat2-webapp-rxjah4bntxkd2.yml
@@ -31,7 +31,7 @@ jobs:
         run: zip release.zip ./* -r
 
       - name: Upload artifact for deployment job
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: node-app
           path: release.zip
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Download artifact from build job
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: node-app
 


### PR DESCRIPTION
Ticket: https://mural.atlassian.net/browse/PE-5008

This PR upgrades artifact and cache actions to v4 since older versions have been deprecated.

> Artifact actions v3 will be closing down by January 30, 2025
> Starting February 1st, 2025, we are closing down v1-v2 of actions/cache
